### PR TITLE
Feature/issue 6 add actor id to document metadata

### DIFF
--- a/Nebula.AspNetCore.Tests/Store/FlowerStore.cs
+++ b/Nebula.AspNetCore.Tests/Store/FlowerStore.cs
@@ -12,7 +12,9 @@ namespace Nebula.AspNetCore.Tests.Store
         private readonly DocumentStoreConfig _config;
         private readonly IVersionedDocumentStoreClient _client;
 
-        public FlowerStore(IDocumentDbAccessProvider dbAccessProvider) : base(dbAccessProvider, false)
+        public FlowerStore(
+            IDocumentDbAccessProvider dbAccessProvider,
+            IDocumentMetadataSource metadataSource) : base(dbAccessProvider, false)
         {
             var config = new DocumentStoreConfigBuilder("Flowers");
 
@@ -24,7 +26,7 @@ namespace Nebula.AspNetCore.Tests.Store
                 .Finish();
 
             _config = config.Finish();
-            _client = CreateStoreLogic(DbAccess, _config);
+            _client = CreateStoreLogic(DbAccess, _config, metadataSource);
 
             DbAccess.ConfigRegistry.RegisterStoreConfigSource(this);
         }

--- a/Nebula.AspNetCore/DocumentMetadataSource.cs
+++ b/Nebula.AspNetCore/DocumentMetadataSource.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Linq;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+
+namespace Nebula.AspNetCore
+{
+    /// <summary>
+    /// A standard ASP.NET Core document metadata source.
+    /// </summary>
+    public class DocumentMetadataSource : IDocumentMetadataSource
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="DocumentMetadataSource"/> class.
+        /// </summary>
+        /// <param name="httpContextAccessor">The http context accessor.</param>
+        public DocumentMetadataSource(IHttpContextAccessor httpContextAccessor)
+        {
+            if (httpContextAccessor == null)
+                throw new ArgumentNullException(nameof(httpContextAccessor));
+
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        /// <inheritdoc />
+        public string GetActorId()
+        {
+            var claims = _httpContextAccessor.HttpContext.User.Claims.ToArray();
+
+            string actorId = null;
+
+            var subClaim =
+                claims.SingleOrDefault(c => c.Type == ClaimTypes.NameIdentifier)
+                ?? claims.SingleOrDefault(c => c.Type == "sub");
+
+            if (subClaim != null)
+            {
+                actorId = subClaim.Value;
+            }
+
+            return actorId;
+        }
+    }
+}

--- a/Nebula.AspNetCore/NebulaServiceCollectionExtensions.cs
+++ b/Nebula.AspNetCore/NebulaServiceCollectionExtensions.cs
@@ -30,7 +30,11 @@ namespace Nebula.AspNetCore
             services.TryAdd(ServiceDescriptor.Singleton<IDocumentDbAccessFactory, StandardDbAccessFactory>(
                 provider => new StandardDbAccessFactory(serviceName, config)));
 
-            services.TryAdd(ServiceDescriptor.Singleton<IDocumentDbAccessProvider, DocumentDbAccessProvider>());
+            services.TryAddSingleton<IDocumentDbAccessProvider, DocumentDbAccessProvider>();
+
+            services.AddHttpContextAccessor();
+
+            services.TryAddScoped<IDocumentMetadataSource, DocumentMetadataSource>();
 
             return services;
         }
@@ -78,7 +82,11 @@ namespace Nebula.AspNetCore
             services.TryAdd(ServiceDescriptor.Singleton<IDocumentDbAccessFactory, ConfigDbAccessFactory>(
                 provider => new ConfigDbAccessFactory(serviceName, provider.GetRequiredService<IOptions<NebulaConfig>>())));
 
-            services.TryAdd(ServiceDescriptor.Singleton<IDocumentDbAccessProvider, DocumentDbAccessProvider>());
+            services.TryAddSingleton<IDocumentDbAccessProvider, DocumentDbAccessProvider>();
+
+            services.AddHttpContextAccessor();
+
+            services.TryAddScoped<IDocumentMetadataSource, DocumentMetadataSource>();
 
             return services;
         }

--- a/Nebula/DocumentStoreClient.cs
+++ b/Nebula/DocumentStoreClient.cs
@@ -349,6 +349,9 @@ namespace Nebula
 
             [JsonProperty("@service")]
             public string Service { get; set; }
+
+            [JsonProperty("@actor", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+            public string Actor { get; set; }
         }
     }
 }

--- a/Nebula/IDocumentMetadataSource.cs
+++ b/Nebula/IDocumentMetadataSource.cs
@@ -1,0 +1,14 @@
+﻿namespace Nebula
+{
+    /// <summary>
+    /// Defines methods for retrieving document metadata.
+    /// </summary>
+    public interface IDocumentMetadataSource
+    {
+        /// <summary>
+        /// Gets the current actor id.
+        /// </summary>
+        /// <returns>The actor id.</returns>
+        string GetActorId();
+    }
+}

--- a/Nebula/NullDocumentMetadataSource.cs
+++ b/Nebula/NullDocumentMetadataSource.cs
@@ -1,0 +1,14 @@
+﻿namespace Nebula
+{
+    /// <summary>
+    /// A document metadata source that provides no data.
+    /// </summary>
+    internal class NullDocumentMetadataSource : IDocumentMetadataSource
+    {
+        /// <inheritdoc />
+        public string GetActorId()
+        {
+            return null;
+        }
+    }
+}

--- a/Nebula/Versioned/VersionedDocumentMetadata.cs
+++ b/Nebula/Versioned/VersionedDocumentMetadata.cs
@@ -15,6 +15,19 @@ namespace Nebula.Versioned
         /// <param name="createdTime">The created time.</param>
         /// <param name="modifiedTime">The modified time.</param>
         public VersionedDocumentMetadata(int version, bool isDeleted, DateTime createdTime, DateTime modifiedTime)
+            : this(version, isDeleted, createdTime, modifiedTime, null)
+        {
+        }
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="VersionedDocumentMetadata"/> class.
+        /// </summary>
+        /// <param name="version">The document version</param>
+        /// <param name="isDeleted">A <c>boolean</c> indicating whether the document is deleted.</param>
+        /// <param name="createdTime">The created time.</param>
+        /// <param name="modifiedTime">The modified time.</param>
+        /// <param name="actorId">The id of the actor associated with the change.</param>
+        public VersionedDocumentMetadata(int version, bool isDeleted, DateTime createdTime, DateTime modifiedTime, string actorId)
         {
             if (version <= 0)
                 throw new ArgumentOutOfRangeException(nameof(version), "Version must be positive integer");
@@ -27,10 +40,13 @@ namespace Nebula.Versioned
             if (modifiedTime.Kind != DateTimeKind.Utc)
                 throw new ArgumentException("UTC time is required", nameof(modifiedTime));
 
+            // actorId may be null.
+
             Version = version;
             IsDeleted = isDeleted;
             CreatedTime = createdTime;
             ModifiedTime = modifiedTime;
+            ActorId = actorId;
         }
 
         /// <summary>
@@ -52,5 +68,10 @@ namespace Nebula.Versioned
         /// Gets the document last modified time in UTC.
         /// </summary>
         public DateTime ModifiedTime { get; }
+        
+        /// <summary>
+        /// Gets the id of the actor associated with the change.
+        /// </summary>
+        public string ActorId { get; }
     }
 }

--- a/Nebula/Versioned/VersionedDocumentStore.cs
+++ b/Nebula/Versioned/VersionedDocumentStore.cs
@@ -74,6 +74,21 @@ namespace Nebula.Versioned
             return new VersionedDocumentStoreClient(documentDbAccess, config);
         }
 
+        protected static IVersionedDocumentStoreClient CreateStoreLogic(
+            IDocumentDbAccess dbAccess,
+            DocumentStoreConfig config,
+            IDocumentMetadataSource metadataSource)
+        {
+            var documentDbAccess = dbAccess as DocumentDbAccess;
+
+            if (documentDbAccess == null)
+            {
+                throw new InvalidOperationException("Document db access interface is not a supported type");
+            }
+
+            return new VersionedDocumentStoreClient(documentDbAccess, config, metadataSource);
+        }
+
         protected void ThrowTerminatingError(string message, Exception exception = null)
         {
             throw new NebulaStoreException(message, exception);


### PR DESCRIPTION
Changes to add an optional action id to the document metadata that is stored and retrieved on read.