### PR TITLE
Updated UpsertDocumentAsync operation result to include document metadata

### DIFF
--- a/Nebula/Nebula.csproj
+++ b/Nebula/Nebula.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Nebula</AssemblyName>
     <RootNamespace>Nebula</RootNamespace>
     <PackageId>CloudMaker.Nebula.Core</PackageId>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Authors>CloudMaker</Authors>
     <Company>Cloud Maker</Company>
     <Description></Description>

--- a/Nebula/Versioned/VersionedDocumentStoreClient.cs
+++ b/Nebula/Versioned/VersionedDocumentStoreClient.cs
@@ -79,7 +79,9 @@ namespace Nebula.Versioned
 
             await CreateDocumentAsync(dbRecord, existingDocument);
 
-            return new VersionedDocumentUpsertResult<TDocument>(documentId, version, document);
+            var updatedDocument = await GetDocumentAsync(documentId, version, mapping);
+
+            return new VersionedDocumentUpsertResult<TDocument>(documentId, updatedDocument.Metadata, updatedDocument.Document);
         }
 
         /// <inheritdoc />

--- a/Nebula/Versioned/VersionedDocumentStoreClient.cs
+++ b/Nebula/Versioned/VersionedDocumentStoreClient.cs
@@ -80,6 +80,10 @@ namespace Nebula.Versioned
             await CreateDocumentAsync(dbRecord, existingDocument);
 
             var updatedDocument = await GetDocumentAsync(documentId, version, mapping);
+            if (updatedDocument.ResultType == DocumentReadResultType.Failed)
+            {
+                throw new NebulaStoreException($"Failed to retrieve document: {updatedDocument.FailureDetails.Message}");
+            }
 
             return new VersionedDocumentUpsertResult<TDocument>(documentId, updatedDocument.Metadata, updatedDocument.Document);
         }

--- a/Nebula/Versioned/VersionedDocumentUpsertResult.cs
+++ b/Nebula/Versioned/VersionedDocumentUpsertResult.cs
@@ -11,18 +11,21 @@ namespace Nebula.Versioned
         /// Initialises a new instance of the <see cref="VersionedDocumentUpsertResult{TDocument}"/> class.
         /// </summary>
         /// <param name="documentId">The document id.</param>
-        /// <param name="documentVersion">The document version.</param>
+        /// <param name="metadata">The document metadata.</param>
         /// <param name="document">The document that was stored.</param>
-        public VersionedDocumentUpsertResult(string documentId, int documentVersion, TDocument document)
+        public VersionedDocumentUpsertResult(string documentId, VersionedDocumentMetadata metadata, TDocument document)
         {
             if (documentId == null)
                 throw new ArgumentNullException(nameof(documentId));
+            if (metadata == null)
+                throw new ArgumentNullException(nameof(metadata));
             if (document == null)
                 throw new ArgumentNullException(nameof(document));
 
             DocumentId = documentId;
-            DocumentVersion = documentVersion;
+            DocumentVersion = metadata.Version;
             Document = document;
+            DocumentWithMetadata = new VersionedDocumentWithMetadata<TDocument>(metadata, document);
         }
 
         /// <summary>
@@ -39,5 +42,10 @@ namespace Nebula.Versioned
         /// Gets the document that was stored.
         /// </summary>
         public TDocument Document { get; }
+
+        /// <summary>
+        /// Gets the document that was stored, along with the version metadata.
+        /// </summary>
+        public VersionedDocumentWithMetadata<TDocument> DocumentWithMetadata { get; }
     }
 }


### PR DESCRIPTION
Updated upsert logic to retrieve the document from the store once it's been inserted so that the metadata can be extracted and returned as part of the upsert result.