### PR TITLE
Removed the use of the '@latest' flag

### DIFF
--- a/Nebula.Tests/Versioned/VersionedDocumentStoreClientTests.cs
+++ b/Nebula.Tests/Versioned/VersionedDocumentStoreClientTests.cs
@@ -137,12 +137,6 @@ namespace Nebula.Tests.Versioned
 
             client.CreateDocumentAsync(Arg.Any<Uri>(), Arg.Any<object>()).Throws<Exception>();
 
-            client.ExecuteStoredProcedureAsync<dynamic>(
-                    Arg.Any<Uri>(),
-                    Arg.Any<RequestOptions>(),
-                    Arg.Any<dynamic[]>())
-                .Throws<Exception>();
-
             await DoDeleteFailureTest<NebulaStoreException>(
                 client, dbAccess, new[] { storeDoc1 }, doc1.Id, storeDoc1.Version, "Failed to write document");
         }
@@ -306,11 +300,7 @@ namespace Nebula.Tests.Versioned
             var client = Substitute.For<IDocumentClient>();
             var dbAccess = await CreateDbAccess(client);
 
-            client.ExecuteStoredProcedureAsync<dynamic>(
-                    Arg.Any<Uri>(),
-                    Arg.Any<RequestOptions>(),
-                    Arg.Any<dynamic[]>())
-                .Throws<Exception>();
+            client.CreateDocumentAsync(Arg.Any<Uri>(), Arg.Any<object>()).Throws<Exception>();
 
             await DoUpsertFailureTest<NebulaStoreException>(
                 client, dbAccess, null, CreateTestDoc1(), 0, "Failed to write document");
@@ -1171,10 +1161,9 @@ namespace Nebula.Tests.Versioned
             }
 
             object savedObj = null;
-            await client.ExecuteStoredProcedureAsync<dynamic>(
+            await client.CreateDocumentAsync(
                 Arg.Any<Uri>(),
-                Arg.Any<RequestOptions>(),
-                Arg.Do<dynamic[]>(args => savedObj = args[0]));
+                Arg.Do<DocumentStoreClient<VersionedDocumentStoreClient.VersionedDbDocument>.DbDocument>(x => savedObj = x));
 
             var storeDoc = CreateDoc(expectedDoc.Id, version);
             SetDocContent(storeDoc, expectedDoc, storeConfig, dbAccess, storeMapping);
@@ -1234,10 +1223,9 @@ namespace Nebula.Tests.Versioned
             }
 
             object savedObj = null;
-            await client.ExecuteStoredProcedureAsync<dynamic>(
+            await client.CreateDocumentAsync(
                 Arg.Any<Uri>(),
-                Arg.Any<RequestOptions>(),
-                Arg.Do<dynamic[]>(args => savedObj = args[0]));
+                Arg.Do<DocumentStoreClient<VersionedDocumentStoreClient.VersionedDbDocument>.DbDocument>(x => savedObj = x));
 
             var storeDoc = CreateDoc(expectedDoc.Id, version + 1);
             SetDocContent(storeDoc, expectedDoc, storeConfig, dbAccess, storeMapping);
@@ -1312,10 +1300,9 @@ namespace Nebula.Tests.Versioned
             }
 
             object savedObj = null;
-            await client.ExecuteStoredProcedureAsync<dynamic>(
+            await client.CreateDocumentAsync(
                 Arg.Any<Uri>(),
-                Arg.Any<RequestOptions>(),
-                Arg.Do<dynamic[]>(args => savedObj = args[0]));
+                Arg.Do<DocumentStoreClient<VersionedDocumentStoreClient.VersionedDbDocument>.DbDocument>(x => savedObj = x));
 
             var logic = new VersionedDocumentStoreClient(dbAccess, storeConfig, metadataSource);
 

--- a/Nebula.Tests/VersionedStorePerformanceTests.cs
+++ b/Nebula.Tests/VersionedStorePerformanceTests.cs
@@ -29,8 +29,8 @@ namespace Nebula.Tests
             // - Rate limiting.
             //
             // Current performance
-            // - Write: 0.5sec
-            // - Read: 0.9sec
+            // - Write: 0.5sec - 1.3sec
+            // - Read: 0.9sec - 0.3
 
             var configManager = new ServiceDbConfigManager("TestService");
             var dbAccess = await CreateDbAccess(configManager);
@@ -66,8 +66,8 @@ namespace Nebula.Tests
             // - Rate limiting.
             //
             // Current performance
-            // - Write: 60sec
-            // - Read: 2.6sec
+            // - Write: 60sec - 80sec
+            // - Read: 2.6sec - 5.2sec
 
             const int numberOfVersions = 20;
 
@@ -110,8 +110,8 @@ namespace Nebula.Tests
             // - Rate limiting.
             //
             // Current performance
-            // - Write: 1.9sec
-            // - Read: 0.1sec
+            // - Write: 1.9sec - 0.9sec
+            // - Read: 0.1sec - 0.1sec
 
             const int numberOfVersions = 20;
 
@@ -156,9 +156,9 @@ namespace Nebula.Tests
             // - Rate limiting.
             //
             // Current performance
-            // - 2nd write: 0.04 sec
-            // - 1000th write: 0.04 sec
-            // - Read: 0.04 sec
+            // - 2nd write: 0.04 sec - 0.3sec
+            // - 1000th write: 0.04 sec - 0.1sec
+            // - Read: 0.04 sec - 0.1sec
             //
             // The current implementation does not work when thrashed with lower RU/s due to the RU cost of
             // the read and write operations. There is a timeout waiting for retries. An improved

--- a/Nebula/Nebula.csproj
+++ b/Nebula/Nebula.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Nebula</AssemblyName>
     <RootNamespace>Nebula</RootNamespace>
     <PackageId>CloudMaker.Nebula.Core</PackageId>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <Authors>CloudMaker</Authors>
     <Company>Cloud Maker</Company>
     <Description></Description>

--- a/Nebula/Versioned/VersionedDocumentStoreClient.cs
+++ b/Nebula/Versioned/VersionedDocumentStoreClient.cs
@@ -77,7 +77,7 @@ namespace Nebula.Versioned
 
             SetDocumentContent(dbRecord, document, mapping);
 
-            await CreateDocumentAsync(dbRecord, existingDocument);
+            await CreateDocumentAsync(dbRecord);
 
             var updatedDocument = await GetDocumentAsync(documentId, version, mapping);
             if (updatedDocument.ResultType == DocumentReadResultType.Failed)
@@ -136,7 +136,7 @@ namespace Nebula.Versioned
 
             SetDocumentContentFromExisting(dbRecord, existingDocument, mapping);
 
-            await CreateDocumentAsync(dbRecord, existingDocument);
+            await CreateDocumentAsync(dbRecord);
         }
 
         /// <inheritdoc />
@@ -315,7 +315,7 @@ namespace Nebula.Versioned
 
             parameters = parameters ?? new DbParameter[0];
 
-            var builtQuery = CreateQueryByLatest(mapping, query, parameters);
+            var builtQuery = CreateQuery(mapping, query, parameters);
             var documents = await ExecuteQueryAsync(builtQuery);
 
             if (documents.Count == 0)
@@ -538,17 +538,13 @@ namespace Nebula.Versioned
             return true;
         }
 
-        private async Task CreateDocumentAsync(VersionedDbDocument newRecord, VersionedDbDocument existingRecord)
-        {
-            await ExecuteStoredProcedureAsync<CreateDocumentStoredProcedure>(newRecord.PartitionKey, newRecord, existingRecord);
-        }
 
         private IQueryable<VersionedDbDocument> CreateQueryById<TDocument>(string id, DocumentTypeMapping<TDocument> mapping)
         {
             var idParameter = new DbParameter("id", id);
             var query = $"[x].{mapping.IdPropertyName} = @id";
 
-            return CreateQueryByLatest(mapping, query, new[] { idParameter });
+            return CreateQuery(mapping, query, new[] { idParameter });
         }
 
         private IQueryable<VersionedDbDocument> CreateQueryById<TDocument>(string id, int version, DocumentTypeMapping<TDocument> mapping)
@@ -585,23 +581,7 @@ namespace Nebula.Versioned
 
         private IQueryable<VersionedDbDocument> CreateQueryAll<TDocument>(DocumentTypeMapping<TDocument> mapping)
         {
-            return CreateQueryByLatest(mapping, null);
-        }
-
-        private IQueryable<VersionedDbDocument> CreateQueryByLatest<TDocument>(
-            DocumentTypeMapping<TDocument> mapping,
-            string query,
-            IEnumerable<DbParameter> parameters = null)
-        {
-            if (query != null)
-            {
-                query += " AND ";
-            }
-
-            // The first version is always fetched to get the creation time.
-            query += "(c['@latest'] = true OR c['@version'] = 1)";
-
-            return CreateQuery(mapping, query, parameters);
+            return CreateQuery(mapping, null);
         }
 
         private IQueryable<VersionedDbDocument> CreateQueryByVersion<TDocument>(
@@ -671,7 +651,7 @@ namespace Nebula.Versioned
 
             var query = $"[x].{mapping.IdPropertyName} IN ({inIds})";
 
-            return CreateQueryByLatest(mapping, query);
+            return CreateQuery(mapping, query);
         }
 
         private SqlQuerySpec CreateQuerySpec(string queryText, IEnumerable<DbParameter> parameters)


### PR DESCRIPTION
In order to address https://github.com/cloud-maker-ai/Nebula/issues/15, the first thing we need to do is remove the use of the `@latest` flag. This is what this PR does.

To fully address the issue, we'll need to also clean up any code that is creating/loading the `CreateDocumentStoredProcedure` and address the performance hit, or, depending on the approach decided, bring the `@latest` flag back, along with additional metadata to hold original timestamps.