### PR TITLE
Re-instated @latest flag optimisations and added timestamp in document metadata

### DIFF
--- a/Nebula.Tests/Versioned/VersionedDocumentStoreClientTests.cs
+++ b/Nebula.Tests/Versioned/VersionedDocumentStoreClientTests.cs
@@ -137,6 +137,12 @@ namespace Nebula.Tests.Versioned
 
             client.CreateDocumentAsync(Arg.Any<Uri>(), Arg.Any<object>()).Throws<Exception>();
 
+            client.ExecuteStoredProcedureAsync<dynamic>(
+                    Arg.Any<Uri>(),
+                    Arg.Any<RequestOptions>(),
+                    Arg.Any<dynamic[]>())
+                .Throws<Exception>();
+
             await DoDeleteFailureTest<NebulaStoreException>(
                 client, dbAccess, new[] { storeDoc1 }, doc1.Id, storeDoc1.Version, "Failed to write document");
         }
@@ -300,7 +306,11 @@ namespace Nebula.Tests.Versioned
             var client = Substitute.For<IDocumentClient>();
             var dbAccess = await CreateDbAccess(client);
 
-            client.CreateDocumentAsync(Arg.Any<Uri>(), Arg.Any<object>()).Throws<Exception>();
+            client.ExecuteStoredProcedureAsync<dynamic>(
+                    Arg.Any<Uri>(),
+                    Arg.Any<RequestOptions>(),
+                    Arg.Any<dynamic[]>())
+                .Throws<Exception>();
 
             await DoUpsertFailureTest<NebulaStoreException>(
                 client, dbAccess, null, CreateTestDoc1(), 0, "Failed to write document");
@@ -1161,9 +1171,10 @@ namespace Nebula.Tests.Versioned
             }
 
             object savedObj = null;
-            await client.CreateDocumentAsync(
+            await client.ExecuteStoredProcedureAsync<dynamic>(
                 Arg.Any<Uri>(),
-                Arg.Do<DocumentStoreClient<VersionedDocumentStoreClient.VersionedDbDocument>.DbDocument>(x => savedObj = x));
+                Arg.Any<RequestOptions>(),
+                Arg.Do<dynamic[]>(args => savedObj = args[0]));
 
             var storeDoc = CreateDoc(expectedDoc.Id, version);
             SetDocContent(storeDoc, expectedDoc, storeConfig, dbAccess, storeMapping);
@@ -1223,9 +1234,10 @@ namespace Nebula.Tests.Versioned
             }
 
             object savedObj = null;
-            await client.CreateDocumentAsync(
+            await client.ExecuteStoredProcedureAsync<dynamic>(
                 Arg.Any<Uri>(),
-                Arg.Do<DocumentStoreClient<VersionedDocumentStoreClient.VersionedDbDocument>.DbDocument>(x => savedObj = x));
+                Arg.Any<RequestOptions>(),
+                Arg.Do<dynamic[]>(args => savedObj = args[0]));
 
             var storeDoc = CreateDoc(expectedDoc.Id, version + 1);
             SetDocContent(storeDoc, expectedDoc, storeConfig, dbAccess, storeMapping);
@@ -1300,9 +1312,10 @@ namespace Nebula.Tests.Versioned
             }
 
             object savedObj = null;
-            await client.CreateDocumentAsync(
+            await client.ExecuteStoredProcedureAsync<dynamic>(
                 Arg.Any<Uri>(),
-                Arg.Do<DocumentStoreClient<VersionedDocumentStoreClient.VersionedDbDocument>.DbDocument>(x => savedObj = x));
+                Arg.Any<RequestOptions>(),
+                Arg.Do<dynamic[]>(args => savedObj = args[0]));
 
             var logic = new VersionedDocumentStoreClient(dbAccess, storeConfig, metadataSource);
 

--- a/Nebula.Tests/VersionedStorePerformanceTests.cs
+++ b/Nebula.Tests/VersionedStorePerformanceTests.cs
@@ -29,8 +29,8 @@ namespace Nebula.Tests
             // - Rate limiting.
             //
             // Current performance
-            // - Write: 0.5sec - 1.3sec
-            // - Read: 0.9sec - 0.3
+            // - Write: 0.5sec
+            // - Read: 0.9sec
 
             var configManager = new ServiceDbConfigManager("TestService");
             var dbAccess = await CreateDbAccess(configManager);
@@ -66,8 +66,8 @@ namespace Nebula.Tests
             // - Rate limiting.
             //
             // Current performance
-            // - Write: 60sec - 80sec
-            // - Read: 2.6sec - 5.2sec
+            // - Write: 60sec
+            // - Read: 2.6sec
 
             const int numberOfVersions = 20;
 
@@ -110,8 +110,8 @@ namespace Nebula.Tests
             // - Rate limiting.
             //
             // Current performance
-            // - Write: 1.9sec - 0.9sec
-            // - Read: 0.1sec - 0.1sec
+            // - Write: 1.9sec
+            // - Read: 0.1sec
 
             const int numberOfVersions = 20;
 
@@ -156,9 +156,9 @@ namespace Nebula.Tests
             // - Rate limiting.
             //
             // Current performance
-            // - 2nd write: 0.04 sec - 0.3sec
-            // - 1000th write: 0.04 sec - 0.1sec
-            // - Read: 0.04 sec - 0.1sec
+            // - 2nd write: 0.04 sec
+            // - 1000th write: 0.04 sec
+            // - Read: 0.04 sec
             //
             // The current implementation does not work when thrashed with lower RU/s due to the RU cost of
             // the read and write operations. There is a timeout waiting for retries. An improved

--- a/Nebula/DocumentStoreClient.cs
+++ b/Nebula/DocumentStoreClient.cs
@@ -352,6 +352,10 @@ namespace Nebula
 
             [JsonProperty("@actor", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
             public string Actor { get; set; }
+
+            [JsonProperty("@timestamp")]
+            [JsonConverter(typeof(UnixDateTimeConverter))]
+            public new DateTime Timestamp { get; set; }
         }
     }
 }

--- a/Nebula/Nebula.csproj
+++ b/Nebula/Nebula.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Nebula</AssemblyName>
     <RootNamespace>Nebula</RootNamespace>
     <PackageId>CloudMaker.Nebula.Core</PackageId>
-    <Version>1.0.3</Version>
+    <Version>1.0.2</Version>
     <Authors>CloudMaker</Authors>
     <Company>Cloud Maker</Company>
     <Description></Description>

--- a/Nebula/Versioned/VersionedDocumentStoreClient.cs
+++ b/Nebula/Versioned/VersionedDocumentStoreClient.cs
@@ -74,6 +74,7 @@ namespace Nebula.Versioned
             dbRecord.PartitionKey = mapping.PartitionKeyMapper(document);
             dbRecord.Version = version;
             dbRecord.Actor = GetActorId();
+            dbRecord.Timestamp = DateTime.UtcNow;
 
             SetDocumentContent(dbRecord, document, mapping);
 
@@ -133,6 +134,7 @@ namespace Nebula.Versioned
             dbRecord.Version = version;
             dbRecord.Deleted = true;
             dbRecord.Actor = GetActorId();
+            dbRecord.Timestamp = DateTime.UtcNow;
 
             SetDocumentContentFromExisting(dbRecord, existingDocument, mapping);
 


### PR DESCRIPTION
The `@latest` flag on documents was removed in https://github.com/cloud-maker-ai/Nebula/pull/16 to roll out a quick fix to a bug effecting document timestamps cross multiple versions of the same document.

This flag was an important query optimisation and therefore will be re-introduced.

This PR reverts changes to remove the `@latest` flag and fixes by timestamp related bug by introducing a Nebula managed document timestamp.