### PR TITLE
Removed various async blocking calls in integration tests.

### DIFF
--- a/Nebula.Tests/Nebula.Tests.csproj
+++ b/Nebula.Tests/Nebula.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="3.1.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Nebula.Tests/VersionedStoreIntegrationTests.cs
+++ b/Nebula.Tests/VersionedStoreIntegrationTests.cs
@@ -365,7 +365,7 @@ namespace Nebula.Tests
                 })
             };
 
-            Task.WaitAll(tasks.ToArray());
+            await Task.WhenAll(tasks.ToArray());
         }
 
         [Fact]
@@ -389,8 +389,7 @@ namespace Nebula.Tests
             var t1 = Task.Run(async () => await SeedCounterAsync(gala.Id, fruitStore));
             var t2 = Task.Run(async () => await SeedCounterAsync(gala.Id, fruitStore, shouldSleep:true));
 
-            var exception = Assert.Throws<AggregateException>(() => Task.WaitAll(t1, t2));
-            Assert.Equal(typeof(NebulaStoreConcurrencyException), exception.InnerException.GetType());
+            await Assert.ThrowsAsync<NebulaStoreConcurrencyException>(() => Task.WhenAll(t1, t2));
         }
 
         [Fact]

--- a/Nebula.Tests/VersionedStoreTests.cs
+++ b/Nebula.Tests/VersionedStoreTests.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents.Client;
 using Nebula.Config;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Nebula.Tests
 {
-    public abstract class VersionedStoreTests : IDisposable
+    public abstract class VersionedStoreTests : IAsyncLifetime
     {
         private readonly ITestOutputHelper _testOutputHelper;
 
@@ -21,7 +22,12 @@ namespace Nebula.Tests
             _dbAccesses = new List<DocumentDbAccess>();
         }
 
-        public void Dispose()
+        Task IAsyncLifetime.InitializeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        async Task IAsyncLifetime.DisposeAsync()
         {
             // Drop the database.
             if (_dbAccesses.Count > 0)
@@ -35,9 +41,7 @@ namespace Nebula.Tests
 
                 var documentClient = firstDbAccess.GetClient();
 
-                documentClient
-                    .DeleteDatabaseAsync(UriFactory.CreateDatabaseUri(_databaseId))
-                    .Wait();
+                await documentClient.DeleteDatabaseAsync(UriFactory.CreateDatabaseUri(_databaseId));
             }
         }
 


### PR DESCRIPTION
The integration tests use the XUnit test framework. Nebula relies on await/async generally but in the test code there is scattered usages that explicitly block the running thread to execute tasks.

This can lead to deadlocks in XUnit test runners that rely on the threads marshaling continuation back to the original context captured.

Removed various async blocking calls in integration tests.

See: [Issue-22](https://github.com/cloud-maker-ai/Nebula/issues/22)
