### PR TITLE
Improved handling of store configuration updates

### DIFF
--- a/Nebula.Tests/Management/ServiceManagerTests.cs
+++ b/Nebula.Tests/Management/ServiceManagerTests.cs
@@ -93,7 +93,7 @@ namespace Nebula.Tests.Management
 
             var documentDbAccess = new DocumentDbAccess(CreateDbConfig(), configManager, documentClient, dbService, queryPolicy);
 
-            await documentDbAccess.Open();
+            await documentDbAccess.Open(new IDocumentStoreConfigSource[0]);
 
             return documentDbAccess;
         }

--- a/Nebula.Tests/Nebula.Tests.csproj
+++ b/Nebula.Tests/Nebula.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/Nebula.Tests/Versioned/VersionedDocumentStoreClientTests.cs
+++ b/Nebula.Tests/Versioned/VersionedDocumentStoreClientTests.cs
@@ -1022,8 +1022,7 @@ namespace Nebula.Tests.Versioned
             var dbService = Substitute.For<IDocumentDbService>();
 
             var documentDbAccess = new DocumentDbAccess(CreateDbConfig(), configManager, documentClient, dbService, queryPolicy);
-
-            await documentDbAccess.Open();
+            await documentDbAccess.Open(new IDocumentStoreConfigSource[0]);
 
             return documentDbAccess;
         }

--- a/Nebula.Tests/VersionedStoreIntegrationTests.cs
+++ b/Nebula.Tests/VersionedStoreIntegrationTests.cs
@@ -24,15 +24,18 @@ namespace Nebula.Tests
         public async void TestMultipleServices()
         {
             var configManager1 = new ServiceDbConfigManager("TestService1");
-            var dbAccess1 = await CreateDbAccess(configManager1);
+            var dbAccess1 = CreateDbAccess(configManager1);
             var dbAccessProvider1 = new TestDocumentDbAccessProvider(dbAccess1);
 
             var configManager2 = new ServiceDbConfigManager("TestService2");
-            var dbAccess2 = await CreateDbAccess(configManager2);
+            var dbAccess2 = CreateDbAccess(configManager2);
             var dbAccessProvider2 = new TestDocumentDbAccessProvider(dbAccess2);
 
             var fruitStore1 = new FruitStore(dbAccessProvider1);
             var fruitStore2 = new FruitStore(dbAccessProvider2);
+
+            await dbAccess1.Open(new[] { fruitStore1 });
+            await dbAccess2.Open(new[] { fruitStore2 });
 
             var apples = new List<Apple>();
 
@@ -80,11 +83,13 @@ namespace Nebula.Tests
         public async void TestMultipleServiceStores()
         {
             var configManager = new ServiceDbConfigManager("TestService");
-            var dbAccess = await CreateDbAccess(configManager);
+            var dbAccess = CreateDbAccess(configManager);
             var dbAccessProvider = new TestDocumentDbAccessProvider(dbAccess);
 
             var fruitStore = new FruitStore(dbAccessProvider);
             var flowerStore = new FlowerStore(dbAccessProvider);
+
+            await dbAccess.Open(new VersionedDocumentStore[] { fruitStore, flowerStore });
 
             var apples = new List<Apple>();
             var daisies = new List<Daisy>();
@@ -145,10 +150,12 @@ namespace Nebula.Tests
         public async void TestMultipleStoreDocumentTypes()
         {
             var configManager = new ServiceDbConfigManager("TestService");
-            var dbAccess = await CreateDbAccess(configManager);
+            var dbAccess = CreateDbAccess(configManager);
             var dbAccessProvider = new TestDocumentDbAccessProvider(dbAccess);
 
             var fruitStore = new FruitStore(dbAccessProvider);
+
+            await dbAccess.Open(new[] { fruitStore });
 
             var apples = new List<Apple>();
             var pears = new List<Pear>();
@@ -223,15 +230,18 @@ namespace Nebula.Tests
         public async void TestMultipleServicesDocumentPurge()
         {
             var configManager1 = new ServiceDbConfigManager("TestService1");
-            var dbAccess1 = await CreateDbAccess(configManager1);
+            var dbAccess1 = CreateDbAccess(configManager1);
             var dbAccessProvider1 = new TestDocumentDbAccessProvider(dbAccess1);
 
             var configManager2 = new ServiceDbConfigManager("TestService2");
-            var dbAccess2 = await CreateDbAccess(configManager2);
+            var dbAccess2 = CreateDbAccess(configManager2);
             var dbAccessProvider2 = new TestDocumentDbAccessProvider(dbAccess2);
 
             var fruitStore1 = new FruitStore(dbAccessProvider1);
             var fruitStore2 = new FruitStore(dbAccessProvider2);
+
+            await dbAccess1.Open(new[] { fruitStore1 });
+            await dbAccess2.Open(new[] { fruitStore2 });
 
             var apples = new List<Apple>();
 
@@ -292,10 +302,12 @@ namespace Nebula.Tests
         public async void TestLargeNumberOfDocuments()
         {
             var configManager = new ServiceDbConfigManager("TestService");
-            var dbAccess = await CreateDbAccess(configManager);
+            var dbAccess = CreateDbAccess(configManager);
             var dbAccessProvider = new TestDocumentDbAccessProvider(dbAccess);
 
             var fruitStore = new FruitStore(dbAccessProvider);
+
+            await dbAccess.Open(new[] { fruitStore });
 
             var apples = new List<Apple>();
 
@@ -337,46 +349,15 @@ namespace Nebula.Tests
 
         [Fact]
         [Trait("Category", "Integration")]
-        public async void TestServiceRegistrationAndUpdateConcurrency()
-        {
-            // This test performs a concurrency check to ensure that multiple threads can successfully interact with
-            // the same config manager. The config manager is thread safe so multiple stores registering and performing
-            // actions on different threads should produce a consistent result.
-
-            var configManager = new ServiceDbConfigManager("TestService");
-            var dbAccess = await CreateDbAccess(configManager);
-            var dbAccessProvider = new TestDocumentDbAccessProvider(dbAccess);
-
-            List<Task> tasks = new List<Task>
-            {
-                Task.Run(async () =>
-                {
-                    var fruitStore = new FruitStore(dbAccessProvider);
-
-                    var gala = new Apple { Id = Guid.NewGuid(), Type = "Gala" };
-                    await fruitStore.UpsertApple(gala);
-                }),
-                Task.Run(async () =>
-                {
-                    var flowerStore = new FlowerStore(dbAccessProvider);
-
-                    var daisy = new Daisy { Id = Guid.NewGuid(), Colour = "Red" };
-                    await flowerStore.Upsert(daisy);
-                })
-            };
-
-            await Task.WhenAll(tasks.ToArray());
-        }
-
-        [Fact]
-        [Trait("Category", "Integration")]
         public async void TestDbConcurrency()
         {
             var configManager = new ServiceDbConfigManager("TestService");
-            var dbAccess = await CreateDbAccess(configManager);
+            var dbAccess = CreateDbAccess(configManager);
             var dbAccessProvider = new TestDocumentDbAccessProvider(dbAccess);
 
             var fruitStore = new FruitStore(dbAccessProvider);
+
+            await dbAccess.Open(new[] { fruitStore });
 
             var gala = new Apple
             {
@@ -397,10 +378,12 @@ namespace Nebula.Tests
         public async void TestDocumentAttachments()
         {
             var configManager = new ServiceDbConfigManager("TestService");
-            var dbAccess = await CreateDbAccess(configManager);
+            var dbAccess = CreateDbAccess(configManager);
             var dbAccessProvider = new TestDocumentDbAccessProvider(dbAccess);
 
             var store = new EmailStore(dbAccessProvider);
+
+            await dbAccess.Open(new[] { store });
 
             var email = new Email
             {
@@ -431,10 +414,12 @@ namespace Nebula.Tests
         public async void TestDbParameterQueries()
         {
             var configManager = new ServiceDbConfigManager("TestService");
-            var dbAccess = await CreateDbAccess(configManager);
+            var dbAccess = CreateDbAccess(configManager);
             var dbAccessProvider = new TestDocumentDbAccessProvider(dbAccess);
 
             var fruitStore = new FruitStore(dbAccessProvider);
+
+            await dbAccess.Open(new[] { fruitStore });
 
             var pears = new List<Pear>();
 
@@ -479,10 +464,12 @@ namespace Nebula.Tests
         public async void TestMetadataQueries()
         {
             var configManager = new ServiceDbConfigManager("TestService");
-            var dbAccess = await CreateDbAccess(configManager);
+            var dbAccess = CreateDbAccess(configManager);
             var dbAccessProvider = new TestDocumentDbAccessProvider(dbAccess);
 
             var fruitStore = new FruitStore(dbAccessProvider);
+
+            await dbAccess.Open(new[] { fruitStore });
 
             var bartlett = new Pear
             {
@@ -545,10 +532,12 @@ namespace Nebula.Tests
         public async void TestVersionedQueries()
         {
             var configManager = new ServiceDbConfigManager("TestService");
-            var dbAccess = await CreateDbAccess(configManager);
+            var dbAccess = CreateDbAccess(configManager);
             var dbAccessProvider = new TestDocumentDbAccessProvider(dbAccess);
 
             var fruitStore = new FruitStore(dbAccessProvider);
+
+            await dbAccess.Open(new[] { fruitStore });
 
             var bartlett = new Pear
             {
@@ -606,11 +595,13 @@ namespace Nebula.Tests
         public async void TestCustomDocumentMetadata()
         {
             var configManager = new ServiceDbConfigManager("TestService");
-            var dbAccess = await CreateDbAccess(configManager);
+            var dbAccess = CreateDbAccess(configManager);
             var dbAccessProvider = new TestDocumentDbAccessProvider(dbAccess);
             var metadataSource = new TestDocumentMetadataSource("User1");
 
             var fruitStore = new FruitStore(dbAccessProvider, metadataSource);
+
+            await dbAccess.Open(new[] { fruitStore });
 
             var bartlett = new Pear
             {

--- a/Nebula.Tests/VersionedStoreTests.cs
+++ b/Nebula.Tests/VersionedStoreTests.cs
@@ -39,7 +39,7 @@ namespace Nebula.Tests
                     return;
                 }
 
-                var documentClient = firstDbAccess.GetClient();
+                var documentClient = firstDbAccess.DbClient;
 
                 await documentClient.DeleteDatabaseAsync(UriFactory.CreateDatabaseUri(_databaseId));
             }
@@ -50,12 +50,12 @@ namespace Nebula.Tests
             get { return _testOutputHelper; }
         }
 
-        protected async Task<DocumentDbAccess> CreateDbAccess(ServiceDbConfigManager configManager, int collectionRuLimit = 1000)
+        protected DocumentDbAccess CreateDbAccess(
+            ServiceDbConfigManager configManager,
+            int collectionRuLimit = 1000)
         {
             var dbAccess = new DocumentDbAccess(CreateDbConfig(_databaseId, collectionRuLimit), configManager);
             _dbAccesses.Add(dbAccess);
-
-            await dbAccess.Open();
 
             return dbAccess;
         }

--- a/Nebula/Config/IServiceDbConfigRegistry.cs
+++ b/Nebula/Config/IServiceDbConfigRegistry.cs
@@ -4,7 +4,7 @@
     /// Defines methods for managing a service's configuration registry.
     /// </summary>
     /// <remarks>
-    /// <para>The registry accepts configuration from different aspects of a service database. That includes store speicifc
+    /// <para>The registry accepts configuration from different aspects of a service database. That includes store specific
     /// configuration but may also include global configuration that applies overall to the service.</para>
     /// </remarks>
     public interface IServiceDbConfigRegistry
@@ -14,12 +14,5 @@
         /// </summary>
         /// <param name="configSource">The store configuration source.</param>
         void RegisterStoreConfigSource(IDocumentStoreConfigSource configSource);
-
-        /// <summary>
-        /// Checks if a document store configuration source has been registered.
-        /// </summary>
-        /// <param name="configSource">The store configuration source.</param>
-        /// <returns><c>true</c> if the store has been registered; otherwise <c>false</c>.</returns>
-        bool IsStoreConfigRegistered(IDocumentStoreConfigSource configSource);
     }
 }

--- a/Nebula/DocumentDbAccess.cs
+++ b/Nebula/DocumentDbAccess.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.Documents;
 using Nebula.Config;
@@ -33,7 +34,7 @@ namespace Nebula
             _configManager = configManager;
             _queryPolicy = new DocumentQueryPolicy();
 
-            var dbService = new DocumentDbService(dbConfig);
+            var dbService = new DocumentDbService(configManager, dbConfig);
             _dbService = dbService;
             _client = dbService.Client;
         }
@@ -101,6 +102,22 @@ namespace Nebula
         }
 
         /// <summary>
+        /// Gets the document client.
+        /// </summary>
+        internal IDocumentClient DbClient
+        {
+            get
+            {
+                if (!_started)
+                {
+                    throw new NebulaServiceException("Document DB services have not been started");
+                }
+
+                return _client;
+            }
+        }
+
+        /// <summary>
         /// Gets a boolean indicating if the database service has been started.
         /// </summary>
         public bool IsStarted
@@ -108,44 +125,20 @@ namespace Nebula
             get { return _started; }
         }
 
-        /// <summary>
-        /// Gets the document client.
-        /// </summary>
-        /// <returns>The document client.</returns>
-        /// <remarks>
-        /// <para>This operation ensures that the database configuration is current before returning the client. This is
-        /// an expensive operation if the configuration has changed by another process because the database must be
-        /// updated to reflect the changes. In practice, configuration should not be changing if this class is reused
-        /// for the life time of an application.
-        /// </para>
-        /// <para>The config update process is run synchronously.</para>
-        /// </remarks>
-        internal IDocumentClient GetClient()
-        {
-            if (!_started)
-            {
-                throw new NebulaServiceException("Document DB services have not been started");
-            }
-
-            _configManager.EnsureConfigCurrent(_client, _dbConfig);
-
-            return _client;
-        }
-
         /// <inheritdoc />
-        public async Task Open()
+        public async Task Open(IEnumerable<IDocumentStoreConfigSource> storeConfigSources)
         {
+            if (storeConfigSources == null)
+                throw new ArgumentNullException(nameof(storeConfigSources));
+
             if (_started)
             {
                 return;
             }
 
-            await _dbService.StartAsync();
+            await _dbService.StartAsync(storeConfigSources);
 
             _started = true;
-
-            // Do an initial config update run in case any stores have been registered already.
-            _configManager.EnsureConfigCurrent(_client, _dbConfig);
         }
     }
 }

--- a/Nebula/IDocumentDbAccess.cs
+++ b/Nebula/IDocumentDbAccess.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Nebula.Config;
 
 namespace Nebula
@@ -32,6 +33,6 @@ namespace Nebula
         /// table and ensure that the configuration is current. To avoid this startup latency on the first request,
         /// the client is explicitly opened and the configuration is checked/updated.</para>
         /// </remarks>
-        Task Open();
+        Task Open(IEnumerable<IDocumentStoreConfigSource> storeConfigSources);
     }
 }

--- a/Nebula/Nebula.csproj
+++ b/Nebula/Nebula.csproj
@@ -5,7 +5,7 @@
     <AssemblyName>Nebula</AssemblyName>
     <RootNamespace>Nebula</RootNamespace>
     <PackageId>CloudMaker.Nebula.Core</PackageId>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <Authors>CloudMaker</Authors>
     <Company>Cloud Maker</Company>
     <Description></Description>

--- a/Nebula/Service/IDocumentDbService.cs
+++ b/Nebula/Service/IDocumentDbService.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Nebula.Config;
 
 namespace Nebula.Service
 {
@@ -10,7 +12,8 @@ namespace Nebula.Service
         /// <summary>
         /// Starts the service.
         /// </summary>
+        /// <param name="storeConfigSources">The store config sources.</param>
         /// <returns>A task that represents the asynchronous start operation.</returns>
-        Task StartAsync();
+        Task StartAsync(IEnumerable<IDocumentStoreConfigSource> storeConfigSources);
     }
 }

--- a/Nebula/Versioned/VersionedDocumentStore.cs
+++ b/Nebula/Versioned/VersionedDocumentStore.cs
@@ -31,31 +31,6 @@ namespace Nebula.Versioned
             }
         }
 
-        /// <summary>
-        /// Creates a new instance of the <see cref="VersionedDocumentStore"/> class.
-        /// </summary>
-        /// <param name="dbAccess">The db access interface.</param>
-        /// <param name="existingSource">The existing store configuration source.</param>
-        /// <remarks>
-        /// <para>The store is not added to the database configuration registry. <paramref name="existingSource"/> must
-        /// already been registered.</para>
-        /// </remarks>
-        [Obsolete("Az Functions")]
-        protected VersionedDocumentStore(IDocumentDbAccess dbAccess, IDocumentStoreConfigSource existingSource)
-        {
-            if (dbAccess == null)
-                throw new ArgumentNullException(nameof(dbAccess));
-            if (existingSource == null)
-                throw new ArgumentNullException(nameof(existingSource));
-
-            DbAccess = dbAccess;
-
-            if (!dbAccess.ConfigRegistry.IsStoreConfigRegistered(existingSource))
-            {
-                throw new ArgumentException("Store config has not been registed");
-            }
-        }
-
         protected abstract DocumentStoreConfig StoreConfig { get; }
 
         protected abstract IVersionedDocumentStoreClient StoreClient { get; }

--- a/Nebula/Versioned/VersionedDocumentStore.cs
+++ b/Nebula/Versioned/VersionedDocumentStore.cs
@@ -13,11 +13,6 @@ namespace Nebula.Versioned
         /// </summary>
         /// <param name="dbAccessProvider">The db access provider.</param>
         /// <param name="registerConfigSource">A boolean indicating if the config source should be registered.</param>
-        /// <remarks>
-        /// <para>This store is added to the database configuration registry for management if
-        /// <paramref name="registerConfigSource"/> is <c>true</c>.</para>
-        /// <para>If <paramref name="registerConfigSource"/> is false then the store must be registered by the caller.</para>
-        /// </remarks>
         protected VersionedDocumentStore(IDocumentDbAccessProvider dbAccessProvider, bool registerConfigSource)
         {
             if (dbAccessProvider == null)
@@ -29,6 +24,15 @@ namespace Nebula.Versioned
             {
                 DbAccess.ConfigRegistry.RegisterStoreConfigSource(this);
             }
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="VersionedDocumentStore"/> class.
+        /// </summary>
+        /// <param name="dbAccessProvider">The db access provider.</param>
+        protected VersionedDocumentStore(IDocumentDbAccessProvider dbAccessProvider)
+            : this(dbAccessProvider, false)
+        {
         }
 
         protected abstract DocumentStoreConfig StoreConfig { get; }

--- a/Nebula/Versioned/VersionedDocumentStoreClient.cs
+++ b/Nebula/Versioned/VersionedDocumentStoreClient.cs
@@ -654,10 +654,8 @@ namespace Nebula.Versioned
 
             var querySpec = CreateQuerySpec(selectStatement, parameters);
 
-            var client = DbAccess.GetClient();
-
             return MakeClientCall(
-                () => client.CreateDocumentQuery<VersionedDbDocument>(CollectionUri, querySpec, queryOptions),
+                () => DbAccess.DbClient.CreateDocumentQuery<VersionedDbDocument>(CollectionUri, querySpec, queryOptions),
                 "Failed to create document query");
         }
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,16 @@ The wrapped document content is never modified for a particular stored version. 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-    services.AddNebula("FloristService", Configuration);
-    
-    services.AddScoped<FlowerStore>();
+    // Nebula setup:
+    services
+        .AddNebula("Florist", Configuration)
+        .AddNebulaStore<FlowerStore>()
+        .AddNebulaStore<OrderStore>();
+
+    // Normal DI of your store classes:
+    services
+        .AddScoped<FlowerStore>()
+        .AddScoped<OrderStore>();
 }
 ```
 


### PR DESCRIPTION
Store configuration updates have been shifted up to the Document DB service and is only triggered once when the DB access services are first started. This prevents re-configuration happening every time a new store implementation is created by .NET Core DI flows. This will be a significant performance improvement, especially for services with lots of stores and for large data stores (due to less triggering of index re-builds).

Processing configuration in this way allowed the config manager logic to be simplified as well as the removal of a troublesome call to `Wait()`. The blocking `Wait()` call is the only of it's kind the Nebula library and may cause issues with integrations with other libraries. The worst case being potential for a dead lock.